### PR TITLE
Fix objective/explanatory variable names

### DIFF
--- a/ai/0-17_20.py
+++ b/ai/0-17_20.py
@@ -104,9 +104,9 @@ def dump_wine(df: pd.DataFrame, save_to_file: bool) -> None:
   print(df.info())
   print(df.describe())
 
-  explanatory_label = 'Alcohol'
-  objective_labels = ['', 'Proline', 'Color intensity', 'Alcalinity of ash', 'Total phenols', 'Magnesium', 'Flavanoids']
-  X = df.get([explanatory_label])
+  objective_label = 'Alcohol'
+  explanatory_labels = ['', 'Proline', 'Color intensity', 'Alcalinity of ash', 'Total phenols', 'Magnesium', 'Flavanoids']
+  y = df.get(objective_label)
 
   areas = set_layout()
   sns.heatmap(
@@ -115,12 +115,12 @@ def dump_wine(df: pd.DataFrame, save_to_file: bool) -> None:
   )
 
   rs = []
-  for n, label in enumerate(objective_labels):
-    if len(label) == 0:
+  for n, explanatory_label in enumerate(explanatory_labels):
+    if len(explanatory_label) == 0:
       continue
 
-    y = df.get(label)
-    X_train, X_test, y_train, y_test = train_test_split(X, y)
+    X = df.get([explanatory_label])
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size= 0.5, random_state=0)
 
     model = linear_model.LinearRegression().fit(X_train, y_train)
     y_predict = model.predict(X_test)
@@ -139,12 +139,12 @@ def dump_wine(df: pd.DataFrame, save_to_file: bool) -> None:
     desc = f'coef: {model.coef_[0]:.3f}\n'
     desc += f'intercept: {model.intercept_:.3f}\n'
     desc += f'score: {score:.3f}\n'
-    print(label)
+    print(explanatory_label)
     print(desc + f'r2_score: {r2_score:.3f}' + f'pearsonr: {r:.3f}, {p:.3f}')
 
     sns.scatterplot(
       x=explanatory_label,
-      y=label,
+      y=objective_label,
       hue='class',
       data=df,
       ax=areas[n],
@@ -152,13 +152,10 @@ def dump_wine(df: pd.DataFrame, save_to_file: bool) -> None:
     )
 
     areas[n].plot(X_test, y_predict)
-    areas[n].text(X_test.min(), y_predict.max(), desc + f'pearsonr: {r:.3f}', bbox=dict(facecolor='white', alpha=0.5), fontsize=6)
-
-    areas[n].set_xlabel(explanatory_label)
-    areas[n].set_ylabel(label)
+    areas[n].text(X_test.min(), y_predict.min(), explanatory_label + '\n' + desc + f'pearsonr: {r:.3f}', bbox=dict(facecolor='white', alpha=0.5), fontsize=6)
 
   m = max(rs)
-  m_label = objective_labels[rs.index(m)]
+  m_label = explanatory_labels[rs.index(m)]
   print('')
   print(f'Max corelation coefficient with {explanatory_label}: {m_label}')
 


### PR DESCRIPTION
単回帰分析の際に説明変数と目的変数を取り違えたのを修正。

![wine](https://user-images.githubusercontent.com/1362607/127775215-87b8b31d-5993-484e-80af-1ac6bf41d423.png)

```
Proline
coef: 0.002
intercept: 11.704
score: 0.380
r2_score: 0.380pearsonr: 0.644, 0.000
Color intensity
coef: 0.220
intercept: 11.944
score: 0.221
r2_score: 0.221pearsonr: 0.546, 0.000
Alcalinity of ash
coef: -0.099
intercept: 14.992
score: -0.041
r2_score: -0.041pearsonr: -0.310, 0.000
Total phenols
coef: 0.610
intercept: 11.671
score: -0.146
r2_score: -0.146pearsonr: 0.289, 0.000
Magnesium
coef: 0.018
intercept: 11.227
score: 0.037
r2_score: 0.037pearsonr: 0.271, 0.000
Flavanoids
coef: 0.320
intercept: 12.408
score: -0.112
r2_score: -0.112pearsonr: 0.237, 0.001
```

```
coefs Alcohol
Proline                         0.643720
Color intensity                 0.546364
class                           0.328222
Alcalinity of ash               0.310235
Total phenols                   0.289101
Magnesium                       0.270798
Flavanoids                      0.236815
Ash                             0.211545
Nonflavanoid phenols            0.155929
Proanthocyanins                 0.136698
Malic acid                      0.094397
OD280/OD315 of diluted wines    0.072343
Hue                             0.071747
```